### PR TITLE
fix vm.Script usage on node@10

### DIFF
--- a/eval.js
+++ b/eval.js
@@ -21,11 +21,11 @@ module.exports = function (content, filename, scope, includeGlobals) {
     if (typeof filename === 'object') {
       includeGlobals = scope
       scope = filename
-      filename = null
+      filename = ''
     } else if (typeof filename === 'boolean') {
       includeGlobals = filename
       scope = {}
-      filename = null
+      filename = ''
     }
   }
 


### PR DESCRIPTION
After node 10, filename is required to be a string.

```
vm.js:62
      throw new ERR_INVALID_ARG_TYPE('options.filename', 'string', filename);
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options.filename" property must be of type string. Received type object
    at new Script (vm.js:62:13)
    at module.exports (/Users/joaosamouco/code/node-eval/eval.js:68:18)
    at Object.<anonymous> (/Users/joaosamouco/code/node-eval/test.js:12:7)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
    at startup (internal/bootstrap/node.js:285:19)
```