### PR TITLE
Add TypeScript definitions file

### DIFF
--- a/eval.d.ts
+++ b/eval.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { Script } from "vm";
 
 /**

--- a/eval.d.ts
+++ b/eval.d.ts
@@ -1,0 +1,48 @@
+import { Script } from "vm";
+
+/**
+ * A simple way to evaluate a module content in the same way as require() but
+ * without loading it from a file. Effectively, it mimicks the javascript evil
+ * `eval` function but leverages Node's VM module instead.
+ */
+declare const nodeEval: {
+  (
+    /** The content to be evaluated. */
+    content: string | Buffer | Script,
+  ): unknown;
+  (
+    /** The content to be evaluated. */
+    content: string | Buffer | Script,
+    /**
+     * Optional flag to allow/disallow global variables (and require) to be
+     * supplied to the content (default=false).
+     */
+    includeGlobals?: boolean,
+  ): unknown;
+  (
+    /** The content to be evaluated. */
+    content: string | Buffer | Script,
+    /** Optional scope properties are provided as variables to the content. */
+    scope?: Record<string, unknown>,
+    /**
+     * Optional flag to allow/disallow global variables (and require) to be
+     * supplied to the content (default=false).
+     */
+    includeGlobals?: boolean,
+  ): unknown;
+  (
+    /** The content to be evaluated. */
+    content: string | Buffer | Script,
+    /** Optional dummy name to be given (used in stacktraces). */
+    filename?: string,
+    /** Optional scope properties are provided as variables to the content. */
+    scope?: Record<string, unknown>,
+    /**
+     * Optional flag to allow/disallow global variables (and require) to be
+     * supplied to the content (default=false).
+     */
+    includeGlobals?: boolean,
+  ): unknown;
+};
+
+export = nodeEval;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   , "url": "git://github.com/pierrec/node-eval.git"
   }
 , "main": "eval.js"
+, "types": "eval.d.ts"
 , "bugs": { "url" : "http://github.com/pierrec/node-eval/issues" }
 , "licenses":
   [ {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">= 0.8"
   }
 , "dependencies": {
-    "@types/node": "14.0.23"
+    "@types/node": "*"
   , "require-like": ">= 0.1.1"
   }
 , "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "node": ">= 0.8"
   }
 , "dependencies": {
-    "require-like": ">= 0.1.1"
+    "@types/node": "14.0.23"
+  , "require-like": ">= 0.1.1"
   }
 , "devDependencies": {
   }


### PR DESCRIPTION
This adds a simple TypeScript definitions file for this module.

For TypeScript users this adds the correct shape of the `eval` function this module exports, complete with all the different ways a user can pass in arguments, and the different shapes they can be. Thank you for maintaining simple and easy to follow source code so I could type it.

If this project does not want to maintain its own definitions, this PR can be closed, and I will instead make a similar PR to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).

Note: This PR does not change any runtime behavior. It just simply adds a new file for the TS types, and an entry in `package.json` pointing to it.