### PR TITLE
fix: only merge non-enumerable global properties that are not in VM scope

### DIFF
--- a/eval.js
+++ b/eval.js
@@ -48,6 +48,9 @@ module.exports = function (content, filename, scope, includeGlobals) {
         sandbox[name] = global[name]
       }
     })
+    // `console` exists in VM scope, but we want to pipe the output to the
+    // process'
+    sandbox.console = console
     sandbox.require = requireLike(_filename)
   }
 

--- a/eval.js
+++ b/eval.js
@@ -13,9 +13,8 @@ function merge (a, b) {
   return a
 }
 
-var vmGlobals = new vm.Script('vmGlobals = Object.getOwnPropertyNames(globalThis)')
+var vmGlobals = new vm.Script('Object.getOwnPropertyNames(globalThis)')
   .runInNewContext()
-  .vmGlobals
 
 // Return the exports/module.exports variable set in the content
 // content (String|VmScript): required

--- a/eval.js
+++ b/eval.js
@@ -13,6 +13,10 @@ function merge (a, b) {
   return a
 }
 
+var vmGlobals = new vm.Script('vmGlobals = Object.getOwnPropertyNames(globalThis)')
+  .runInNewContext()
+  .vmGlobals
+
 // Return the exports/module.exports variable set in the content
 // content (String|VmScript): required
 module.exports = function (content, filename, scope, includeGlobals) {
@@ -40,9 +44,6 @@ module.exports = function (content, filename, scope, includeGlobals) {
     // Merge all non-enumerable variables on `global`, including console (v10+),
     // process (v12+), URL, etc. We first filter out anything that's already in
     // the VM scope (i.e. those in the ES standard) so we don't have two copies
-    var vmGlobals = Object.getOwnPropertyNames(
-      new vm.Script("vmGlobals = globalThis").runInNewContext().vmGlobals
-    )
     Object.getOwnPropertyNames(global).forEach((name) => {
       if (!vmGlobals.includes(name)) {
         sandbox[name] = global[name]


### PR DESCRIPTION
Follow-up of #27. Fix #29

Case as where #27 failed:

```js
new vm.Script("globalThis.Prism = 1; console.log(Prism)").runInNewContext({ globalThis });
```

Because the `globalThis` in this case is an exotic object, the latter `Prism` isn't actually made a "global".

```js
new vm.Script("console.log({} instanceof Object)").runInNewContext({ console, Object });
```

Logs `false` because `Object` is exotic. Removing `Object` from the scope causes it to log `true`.

The resolution is to filter out anything that's already in the VM scope.

cc @pierrec This is a hotfix.
cc @slorber FYI