### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
 , "main": "eval.js"
 , "types": "eval.d.ts"
 , "bugs": { "url" : "http://github.com/pierrec/node-eval/issues" }
-, "licenses":
-  [ {
-      "type": "MIT"
-    , "url": "http://github.com/pierrec/node-eval/raw/master/LICENSE"
-    }
-  ]
+, "license": "MIT"
 , "engines": {
     "node": ">= 0.8"
   }


### PR DESCRIPTION
Hey, I just started using this package today and noticed the `License` on npm says "none" <details><summary>Preview</summary>
<img src="https://user-images.githubusercontent.com/3742559/161144976-3884e0a3-9b3b-4e12-8ae5-69d987d7cf04.png">
</details>


Turns out, the current value for license in `package.json` is deprecated (see https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license). Hence, this updates the `package.json` to have a valid license value.